### PR TITLE
Make file writable before applying strip

### DIFF
--- a/lib/tooling.ex
+++ b/lib/tooling.ex
@@ -76,11 +76,17 @@ defmodule Desktop.Deployment.Tooling do
     is_binary = extname == ""
     is_library = Regex.match?(~r/\.(so|dylib|smp)($|\.)/, extname)
 
-    cond do
-      os() == MacOS and is_library -> cmd!("strip", ["-x", "-S", file])
-      os() == MacOS and is_binary -> cmd!("strip", ["-u", "-r", file])
-      is_binary || is_library -> cmd!("strip", ["-s", file])
-      true -> :ok
+    strip_args =
+      cond do
+        os() == MacOS and is_library -> ["-x", "-S"]
+        os() == MacOS and is_binary -> ["-u", "-r"]
+        is_binary || is_library -> ["-s"]
+        true -> nil
+      end
+
+    if strip_args do
+      File.chmod!(file, Bitwise.bor(File.lstat!(file).mode, 0o200))
+      cmd!("strip", strip_args ++ [file])
     end
 
     file


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes elixir-desktop/desktop-example-app#31

On macOS, the `strip` command fails with "Permission denied" when processing `.so` files (e.g. NIF libraries like `asn1rt_nif.so`) that have read-only permissions. `strip` modifies files in-place and requires write access.

## Changes

- Call `File.chmod!(file, Bitwise.bor(File.lstat!(file).mode, 0o200))` before running `strip` in `strip_symbols/1`
- This adds the write bit to the file's mode, matching the pattern already used in `file_replace/3` in the same module
- Refactored `strip_symbols/1` to avoid duplicating the chmod call across the three strip branches

## Testing

The fix follows the existing `file_replace/3` pattern which already uses `File.chmod!` to ensure files are writable before modification.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8306a16a-7dee-42e0-b255-4f72cdec09a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8306a16a-7dee-42e0-b255-4f72cdec09a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

