### PR TITLE
!Fix :public_key loading in Mix tasks for macOS signing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,4 +58,4 @@ jobs:
         mix desktop.create_keychain ci
         export MACOS_KEYCHAIN=$HOME/Library/Keychains/macos-build.keychain
         export DEVELOPER_ID=-
-        mix test test/codesign_test.exs
+        mix test test/codesign_test.exs test/locate_uid_test.exs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ on: ["push", "pull_request"]
 env:
   ASDF_VERSION: v0.18.1
   OTP_VERSION: 24.3.4.15
-  ELIXIR_VERSION: 1.14.5
+  ELIXIR_VERSION: 1.15.8
   ELIXIR_VARIANT: -otp-24
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       id: asdf-cache
       with:
         path: /Users/runner/.asdf
-        key: macos-15-asdf-${{ env.ASDF_VERSION }}-otp-${{ env.OTP_VERSION }}
+        key: macos-15-asdf-${{ env.ASDF_VERSION }}-otp-${{ env.OTP_VERSION }}-elixir-${{ env.ELIXIR_VERSION }}${{ env.ELIXIR_VARIANT }}
       
     - name: "Installing Erlang"
       if: steps.asdf-cache.outputs.cache-hit != 'true'
@@ -42,7 +42,7 @@ jobs:
       uses: actions/cache/save@v3
       with:
         path: /Users/runner/.asdf
-        key: macos-15-asdf-${{ env.ASDF_VERSION }}-otp-${{ env.OTP_VERSION }}
+        key: macos-15-asdf-${{ env.ASDF_VERSION }}-otp-${{ env.OTP_VERSION }}-elixir-${{ env.ELIXIR_VERSION }}${{ env.ELIXIR_VARIANT }}
   
     - uses: actions/checkout@v3
     - name: "Create keychain"

--- a/lib/package/macos.ex
+++ b/lib/package/macos.ex
@@ -416,13 +416,23 @@ defmodule Desktop.Deployment.Package.MacOS do
   @friendly_attribute {2, 5, 4, 3}
   def locate_uid(pem_filename) do
     cert = File.read!(pem_filename)
-    # Ensure :public_key is started (see extra_applications in mix.exs)
-    # ref https://elixirforum.com/t/nerves-key-hub-mix-tasks-fail-because-of-missing-pubkey-pem-module/62821/2
-    Application.ensure_all_started(:public_key)
+    ensure_public_key!()
     cert_der = List.keyfind!(:public_key.pem_decode(cert), :Certificate, 0)
 
     :public_key.der_decode(:Certificate, elem(cert_der, 1))
     |> scan()
+  end
+
+  # Mix tasks do not automatically put OTP apps on the code path the way a
+  # started release does. Mix.ensure_application!/1 loads :public_key (and
+  # crypto/asn1) onto the path; ensure_all_started/1 then starts them.
+  # Application.ensure_all_started/1 alone is not enough in Mix task context
+  # and silently returning {:error, _} left pem_decode undefined on CI.
+  # ref https://elixirforum.com/t/nerves-key-hub-mix-tasks-fail-because-of-missing-pubkey-pem-module/62821/2
+  defp ensure_public_key! do
+    Mix.ensure_application!(:public_key)
+    {:ok, _} = Application.ensure_all_started(:public_key)
+    :ok
   end
 
   def find_developer_id() do

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Desktop.Deployment.MixProject do
     [
       app: :desktop_deployment,
       version: @version,
-      elixir: "~> 1.10",
+      elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       # compilers: Mix.compilers(),
       start_permanent: Mix.env() == :prod,

--- a/test/locate_uid_test.exs
+++ b/test/locate_uid_test.exs
@@ -8,29 +8,31 @@ defmodule LocateUidTest do
     key = Path.join(dir, "desktop-deployment-test-key.pem")
     cert = Path.join(dir, "desktop-deployment-test-cert.pem")
 
-    {_, 0} =
-      System.cmd("openssl", [
-        "req",
-        "-x509",
-        "-newkey",
-        "rsa:2048",
-        "-keyout",
-        key,
-        "-out",
-        cert,
-        "-days",
-        "1",
-        "-nodes",
-        "-subj",
-        "/CN=Desktop Deployment Test (TESTUID)"
-      ])
+    try do
+      {_, 0} =
+        System.cmd("openssl", [
+          "req",
+          "-x509",
+          "-newkey",
+          "rsa:2048",
+          "-keyout",
+          key,
+          "-out",
+          cert,
+          "-days",
+          "1",
+          "-nodes",
+          "-subj",
+          "/CN=Desktop Deployment Test (TESTUID)"
+        ])
 
-    # Must not raise UndefinedFunctionError for :public_key.pem_decode/1
-    uids = MacOS.locate_uid(cert)
-    assert is_list(uids)
-    assert "TESTUID" in uids
-  after
-    File.rm(Path.join(System.tmp_dir!(), "desktop-deployment-test-key.pem"))
-    File.rm(Path.join(System.tmp_dir!(), "desktop-deployment-test-cert.pem"))
+      # Must not raise UndefinedFunctionError for :public_key.pem_decode/1
+      uids = MacOS.locate_uid(cert)
+      assert is_list(uids)
+      assert "TESTUID" in uids
+    after
+      File.rm(key)
+      File.rm(cert)
+    end
   end
 end

--- a/test/locate_uid_test.exs
+++ b/test/locate_uid_test.exs
@@ -1,0 +1,36 @@
+defmodule LocateUidTest do
+  use ExUnit.Case
+
+  alias Desktop.Deployment.Package.MacOS
+
+  test "locate_uid/1 can decode a PEM after ensuring :public_key is available" do
+    dir = System.tmp_dir!()
+    key = Path.join(dir, "desktop-deployment-test-key.pem")
+    cert = Path.join(dir, "desktop-deployment-test-cert.pem")
+
+    {_, 0} =
+      System.cmd("openssl", [
+        "req",
+        "-x509",
+        "-newkey",
+        "rsa:2048",
+        "-keyout",
+        key,
+        "-out",
+        cert,
+        "-days",
+        "1",
+        "-nodes",
+        "-subj",
+        "/CN=Desktop Deployment Test (TESTUID)"
+      ])
+
+    # Must not raise UndefinedFunctionError for :public_key.pem_decode/1
+    uids = MacOS.locate_uid(cert)
+    assert is_list(uids)
+    assert "TESTUID" in uids
+  after
+    File.rm(Path.join(System.tmp_dir!(), "desktop-deployment-test-key.pem"))
+    File.rm(Path.join(System.tmp_dir!(), "desktop-deployment-test-cert.pem"))
+  end
+end

--- a/test/locate_uid_test.exs
+++ b/test/locate_uid_test.exs
@@ -3,6 +3,13 @@ defmodule LocateUidTest do
 
   alias Desktop.Deployment.Package.MacOS
 
+  # Regression for:
+  #   UndefinedFunctionError: function :public_key.pem_decode/1 is undefined
+  #   (module :public_key is not available)
+  #
+  # That failure happened in Mix task context when only Application.ensure_all_started/1
+  # was used (and its error ignored). locate_uid/1 must load :public_key via
+  # Mix.ensure_application!/1 and then start it before calling pem_decode/1.
   test "locate_uid/1 can decode a PEM after ensuring :public_key is available" do
     dir = System.tmp_dir!()
     key = Path.join(dir, "desktop-deployment-test-key.pem")
@@ -25,6 +32,10 @@ defmodule LocateUidTest do
           "-subj",
           "/CN=Desktop Deployment Test (TESTUID)"
         ])
+
+      # Force ensure_public_key!/0 to re-start :public_key the way a Mix task would
+      # after the app is not already up.
+      _ = Application.stop(:public_key)
 
       # Must not raise UndefinedFunctionError for :public_key.pem_decode/1
       uids = MacOS.locate_uid(cert)


### PR DESCRIPTION
## Summary
`mix desktop.create_keychain` fails on CI with:

```
** (UndefinedFunctionError) function :public_key.pem_decode/1 is undefined (module :public_key is not available)
```

#14 replaced `Mix.ensure_application!(:public_key)` with `Application.ensure_all_started(:public_key)` and ignored the return value. In Mix task context that is not enough: OTP libs are not on the code path the way they are in a started release, so `:public_key.pem_decode/1` fails when packaging/signing on macOS.

## Fix
Restore the pattern Elixir itself uses in `Mix.Utils` (e.g. HTTPS fetch):

1. `Mix.ensure_application!(:public_key)` — put `:public_key` / `:crypto` / `:asn1` on the path and load them
2. `{:ok, _} = Application.ensure_all_started(:public_key)` — start them and fail loudly if that fails

`Mix.ensure_application!/1` remains a documented public API since Elixir 1.15.

## Test plan
- [x] `mix test test/locate_uid_test.exs` — generates a self-signed PEM and asserts `locate_uid/1` decodes without `UndefinedFunctionError`
- [ ] Re-run macOS binary CI against a consumer (e.g. ddrive) that depends on this commit