### PR TITLE
macos: enable host-driven BEAM restart in host-first bundle

### DIFF
--- a/lib/package/macos.ex
+++ b/lib/package/macos.ex
@@ -59,6 +59,13 @@ defmodule Desktop.Deployment.Package.MacOS do
 
     [lifetime]
     mode = reconnect
+    # Host-driven BEAM restart (replaces the heart watchdog). The native
+    # DesktopWebView host watches its child BEAM process and respawns it on
+    # any exit; `system.prepare_quit` from Elixir suppresses respawn during a
+    # user-initiated quit. The Erlang release does not need -heart here.
+    restart_beam = true
+    restart_max_attempts = 0
+    restart_backoff_ms = 500
     """
 
     # Host binaries (e.g. DesktopWebView) look for <executable>.ini next to Resources.


### PR DESCRIPTION
## Summary

Set the new `[lifetime]` INI keys (`restart_beam`, `restart_max_attempts`, `restart_backoff_ms`) when packaging the host-first macOS DesktopWebView bundle. This activates the native host's child-exit watcher added in [elixir-desktop/webview#4](https://github.com/elixir-desktop/webview/pull/4) so the host (not `heart`) drives BEAM restart.

The host-first layout makes the native process the long-lived one, which inverts the heart model. With these settings the host watches the BEAM child, applies an exponential backoff, and respawns. `system.prepare_quit` from Elixir still suppresses respawn during a user-initiated quit.

The Erlang release generated by this packaging does not need `-heart`; the release script can run BEAM directly and the host takes care of restarts.

## Test plan

- [ ] Build a host-first macOS DMG with `Desktop.Deployment.Package.MacOS`; verify generated `DesktopWebView.ini` contains the three new keys in `[lifetime]`
- [ ] Confirm packaging does not regress other INI keys or layout
