### PR TITLE
ci: fix mix format --check-formatted in lib/package/macos.ex

### DIFF
--- a/lib/package/macos.ex
+++ b/lib/package/macos.ex
@@ -18,8 +18,12 @@ defmodule Desktop.Deployment.Package.MacOS do
 
   def release(%Package{} = pkg) do
     case pkg.macos_layout do
-      :host_first -> release_host_first(pkg)
-      :release_first -> release_release_first(pkg)
+      :host_first ->
+        release_host_first(pkg)
+
+      :release_first ->
+        release_release_first(pkg)
+
       other ->
         raise "Unknown macos_layout #{inspect(other)}. Use :host_first or :release_first."
     end


### PR DESCRIPTION
## Summary

`mix lint` fails on `main` because `lib/package/macos.ex` is not formatted.

The `release/1` `case` introduced in #18 uses a one-line branch form. The
current `mix format` rewrites it with blank lines between branches, so
`format --check-formatted` (run by the `lint` alias) rejects the file.

Reformat the file so `mix lint` passes in CI.

## Test plan

- [ ] Confirm `mix format --check-formatted` passes locally
- [ ] Confirm `mix lint` (format + credo) passes locally
- [ ] Confirm the `test mix.create_keychain` workflow passes on this PR

Closes the failing CI on main.

Made with [Cursor](https://cursor.com)